### PR TITLE
Fix `libaio.so.1` not found issue on Ubuntu 24.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Supports Linux, macOS, and Windows runners.
 ```yml
 - name: Set up Oracle Instant Client
   uses: iamazeem/setup-oracle-instant-client-action@v1
+
+- name: Check sqlplus version
+  run: sqlplus -V
 ```
 
 See [CI workflow](./.github/workflows/ci.yml) for a detailed example with

--- a/scripts/setup.bash
+++ b/scripts/setup.bash
@@ -11,6 +11,9 @@ echo "[INF] - RUNNER_ARCH: $RUNNER_ARCH"
 INSTALL_PATH=
 
 if [[ $RUNNER_OS == "Linux" ]]; then
+    if [[ -f /usr/lib/x86_64-linux-gnu/libaio.so.1t64 ]]; then
+        sudo ln -sr /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1
+    fi
     URLS=()
     if [[ $RUNNER_ARCH == "X86" ]]; then
         URLS=(


### PR DESCRIPTION
Related to #1.